### PR TITLE
docs(eslint-plugin): [no-use-before-define] fix typo and outdated issue

### DIFF
--- a/packages/eslint-plugin/docs/rules/no-use-before-define.md
+++ b/packages/eslint-plugin/docs/rules/no-use-before-define.md
@@ -1,7 +1,5 @@
 # Disallow the use of variables before they are defined (`no-use-before-define`)
 
-## PLEASE READ THIS ISSUE BEFORE USING THIS RULE [#1856](https://github.com/typescript-eslint/typescript-eslint/issues/1856)
-
 ## Rule Details
 
 This rule extends the base [`eslint/no-use-before-define`](https://eslint.org/docs/rules/no-use-before-define) rule.
@@ -42,10 +40,10 @@ const defaultOptions: Options = {
 If this is `true`, this rule warns every reference to a enum before the enum declaration.
 If this is `false`, this rule will ignore references to enums, when the reference is in a child scope.
 
-Examples of **incorrect** code for the `{ "enums": false }` option:
+Examples of **incorrect** code for the `{ "enums": true }` option:
 
 ```ts
-/*eslint no-use-before-define: ["error", { "enums": false }]*/
+/*eslint no-use-before-define: ["error", { "enums": true }]*/
 
 const x = Foo.FOO;
 


### PR DESCRIPTION
* https://github.com/typescript-eslint/typescript-eslint/issues/1856 has been closed since last summer

* Fix typo in `enums` configuration example